### PR TITLE
fix typo

### DIFF
--- a/aws-mon.sh
+++ b/aws-mon.sh
@@ -328,7 +328,7 @@ CLOUDWATCH_OPTS="--namespace System/Linux"
 if [ -n "$PROFILE" ]; then
     CLOUDWATCH_OPTS="$CLOUDWATCH_OPTS --profile $PROFILE"
 fi
-if [ -n "$asg" ] && [ $ASG_ONLY -eq 1]; then
+if [ -n "$asg" ] && [ $ASG_ONLY -eq 1 ]; then
     CLOUDWATCH_OPTS="$CLOUDWATCH_OPTS --dimensions AutoScalingGroupName=$asg"
 else
     CLOUDWATCH_OPTS="$CLOUDWATCH_OPTS --dimensions InstanceId=$instanceid"


### PR DESCRIPTION
`aws-mon.sh: line 331: [: missing``]'`
when using --autoscaling
